### PR TITLE
Revendor containerd/ttrpc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/Microsoft/go-winio v0.4.14
 github.com/Microsoft/hcsshim d64a16fba14c833a539fcff9a2eabc3191d5db30
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-github.com/containerd/ttrpc 1fb3814edf44a76e0ccf503decf726d994919a9a
+github.com/containerd/ttrpc f969a7f076a2309c3cc5b93ab8fcc2f143cc25cd
 github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
 gotest.tools v2.3.0
 github.com/google/go-cmp v0.2.0

--- a/vendor/github.com/containerd/ttrpc/services.go
+++ b/vendor/github.com/containerd/ttrpc/services.go
@@ -152,5 +152,5 @@ func convertCode(err error) codes.Code {
 }
 
 func fullPath(service, method string) string {
-	return "/" + path.Join("/", service, method)
+	return "/" + path.Join(service, method)
 }


### PR DESCRIPTION
This is just to bring in the fix to TTRPC service names as seen by
interceptors.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>