### PR TITLE
Use registry hosts http client instead of default client

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -63,9 +63,16 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 			}
 			log.G(ctx).Debug("trying alternative url")
 
+			client := http.DefaultClient
+			// Use registry hosts custom client instead.
+			if len(r.hosts) != 0 {
+				if r.hosts[0].Client != nil {
+					client = r.hosts[0].Client
+				}
+			}
 			// Try this first, parse it
 			host := RegistryHost{
-				Client:       http.DefaultClient,
+				Client:       client,
 				Host:         u.Host,
 				Scheme:       u.Scheme,
 				Path:         u.Path,

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -584,7 +584,7 @@ func requestFields(req *http.Request) logrus.Fields {
 			fields[field] = v
 		}
 	}
-
+	fields["http.version"] = req.Proto
 	return logrus.Fields(fields)
 }
 
@@ -602,6 +602,6 @@ func responseFields(resp *http.Response) logrus.Fields {
 			fields[field] = v
 		}
 	}
-
+	fields["http.version"] = resp.Proto
 	return logrus.Fields(fields)
 }


### PR DESCRIPTION
* Use a client passed in from registry hosts instead of http.DefaultClient
so all operations use a custom client if available.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>